### PR TITLE
fix: configure indentation in `switch`

### DIFF
--- a/file-to-lint.js
+++ b/file-to-lint.js
@@ -26,3 +26,14 @@ const doubleArrayValues = (arr) => arr.map(v => v * 2);
     map.set('json', json);
   });
 })();
+
+switch(true) {
+  case true:
+    console.log('True!');
+    break;
+  case false:
+    console.log('False!');
+    break;
+  default:
+    console.log('Neither true or false!');
+}

--- a/index.js
+++ b/index.js
@@ -6,5 +6,8 @@ module.exports = {
   parserOptions: {
     parser: 'babel-eslint',
     ecmaVersion: 6
+  },
+  rules: {
+    indent: ['error', 2, { SwitchCase: 1 }]
   }
 };


### PR DESCRIPTION
The main issue comes from AirBnB used in https://github.com/Yproximite/eslint-config-yprox, but I want to be sure that this rule will be applied everywhere we use eslint-config-base.